### PR TITLE
Fix moisture sensor adc compilation errors

### DIFF
--- a/.github/workflows/esp32-c6-build-advanced.yml
+++ b/.github/workflows/esp32-c6-build-advanced.yml
@@ -1,0 +1,191 @@
+name: Advanced ESP32-C6 Build with ESP-IDF 5.5
+
+on:
+  push:
+    branches: [ main, master, develop ]
+    tags:
+      - 'v*'
+  pull_request:
+    branches: [ main, master, develop ]
+  workflow_dispatch:
+    inputs:
+      release_build:
+        description: 'Build for release'
+        required: false
+        type: boolean
+        default: false
+
+env:
+  ESP_IDF_VERSION: v5.5
+  TARGET: esp32c6
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        build_type: [debug, release]
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: Cache ESP-IDF
+      id: cache-esp-idf
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/esp
+          ~/.espressif
+        key: ${{ runner.os }}-esp-idf-${{ env.ESP_IDF_VERSION }}-${{ env.TARGET }}
+        restore-keys: |
+          ${{ runner.os }}-esp-idf-${{ env.ESP_IDF_VERSION }}-
+          ${{ runner.os }}-esp-idf-
+
+    - name: Setup ESP-IDF
+      uses: espressif/setup-esp-idf@v1
+      with:
+        esp-idf-version: ${{ env.ESP_IDF_VERSION }}
+        targets: ${{ env.TARGET }}
+
+    - name: Cache build
+      uses: actions/cache@v4
+      with:
+        path: |
+          build
+          ~/.ccache
+        key: ${{ runner.os }}-build-${{ env.TARGET }}-${{ matrix.build_type }}-${{ hashFiles('**/CMakeLists.txt', '**/*.c', '**/*.h', '**/*.cpp', '**/*.hpp') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.TARGET }}-${{ matrix.build_type }}-
+          ${{ runner.os }}-build-${{ env.TARGET }}-
+
+    - name: Configure build type
+      run: |
+        if [ "${{ matrix.build_type }}" = "release" ]; then
+          echo "CONFIG_COMPILER_OPTIMIZATION_SIZE=y" >> sdkconfig.defaults
+          echo "CONFIG_COMPILER_OPTIMIZATION_ASSERTIONS_SILENT=y" >> sdkconfig.defaults
+        else
+          echo "CONFIG_COMPILER_OPTIMIZATION_DEBUG=y" >> sdkconfig.defaults
+          echo "CONFIG_COMPILER_OPTIMIZATION_ASSERTIONS_ENABLE=y" >> sdkconfig.defaults
+        fi
+
+    - name: Build project
+      run: |
+        . ${IDF_PATH}/export.sh
+        idf.py build
+
+    - name: Run size analysis
+      run: |
+        . ${IDF_PATH}/export.sh
+        echo "## Size Information for ${{ matrix.build_type }} build" >> $GITHUB_STEP_SUMMARY
+        echo '```' >> $GITHUB_STEP_SUMMARY
+        idf.py size >> $GITHUB_STEP_SUMMARY
+        echo '```' >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "### Component sizes:" >> $GITHUB_STEP_SUMMARY
+        echo '```' >> $GITHUB_STEP_SUMMARY
+        idf.py size-components | head -20 >> $GITHUB_STEP_SUMMARY
+        echo '```' >> $GITHUB_STEP_SUMMARY
+
+    - name: Generate firmware info
+      run: |
+        . ${IDF_PATH}/export.sh
+        BUILD_DIR="build"
+        FW_VERSION=$(git describe --tags --always --dirty)
+        BUILD_TIME=$(date -u +"%Y-%m-%d %H:%M:%S UTC")
+        
+        cat > firmware_info.json << EOF
+        {
+          "version": "${FW_VERSION}",
+          "build_type": "${{ matrix.build_type }}",
+          "build_time": "${BUILD_TIME}",
+          "target": "${{ env.TARGET }}",
+          "idf_version": "${{ env.ESP_IDF_VERSION }}",
+          "sha": "${{ github.sha }}",
+          "files": {
+            "bootloader": "bootloader.bin",
+            "partition_table": "partition-table.bin",
+            "app": "$(basename $BUILD_DIR/*.bin | grep -v bootloader | grep -v partition)"
+          }
+        }
+        EOF
+        
+        cat firmware_info.json
+
+    - name: Package firmware
+      run: |
+        FW_VERSION=$(git describe --tags --always --dirty)
+        PACKAGE_NAME="esp32c6-firmware-${FW_VERSION}-${{ matrix.build_type }}"
+        mkdir -p ${PACKAGE_NAME}
+        
+        cp build/bootloader/bootloader.bin ${PACKAGE_NAME}/
+        cp build/partition_table/partition-table.bin ${PACKAGE_NAME}/
+        cp build/*.bin ${PACKAGE_NAME}/ 2>/dev/null || true
+        cp build/*.elf ${PACKAGE_NAME}/ 2>/dev/null || true
+        cp firmware_info.json ${PACKAGE_NAME}/
+        
+        # Create flash script
+        cat > ${PACKAGE_NAME}/flash.sh << 'EOF'
+        #!/bin/bash
+        PORT=${1:-/dev/ttyUSB0}
+        esptool.py -p $PORT -b 460800 --before default_reset --after hard_reset --chip esp32c6 \
+          write_flash --flash_mode dio --flash_size detect --flash_freq 80m \
+          0x0 bootloader.bin \
+          0x8000 partition-table.bin \
+          0x10000 *.bin
+        EOF
+        chmod +x ${PACKAGE_NAME}/flash.sh
+        
+        # Create README
+        cat > ${PACKAGE_NAME}/README.md << EOF
+        # ESP32-C6 Firmware
+        
+        Version: ${FW_VERSION}
+        Build Type: ${{ matrix.build_type }}
+        Target: ESP32-C6
+        ESP-IDF Version: ${{ env.ESP_IDF_VERSION }}
+        
+        ## Flashing Instructions
+        
+        ### Using flash.sh script:
+        \`\`\`bash
+        ./flash.sh /dev/ttyUSB0
+        \`\`\`
+        
+        ### Manual flash command:
+        \`\`\`bash
+        esptool.py -p /dev/ttyUSB0 -b 460800 --before default_reset --after hard_reset --chip esp32c6 \\
+          write_flash --flash_mode dio --flash_size detect --flash_freq 80m \\
+          0x0 bootloader.bin \\
+          0x8000 partition-table.bin \\
+          0x10000 *.bin
+        \`\`\`
+        EOF
+        
+        tar -czf ${PACKAGE_NAME}.tar.gz ${PACKAGE_NAME}
+        echo "PACKAGE_NAME=${PACKAGE_NAME}" >> $GITHUB_ENV
+
+    - name: Upload firmware package
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ env.PACKAGE_NAME }}
+        path: ${{ env.PACKAGE_NAME }}.tar.gz
+        retention-days: 30
+
+    - name: Create release
+      if: startsWith(github.ref, 'refs/tags/') && matrix.build_type == 'release'
+      uses: softprops/action-gh-release@v1
+      with:
+        files: ${{ env.PACKAGE_NAME }}.tar.gz
+        body: |
+          ESP32-C6 Firmware Release
+          
+          - Target: ESP32-C6
+          - ESP-IDF Version: ${{ env.ESP_IDF_VERSION }}
+          - Build Type: ${{ matrix.build_type }}
+          
+          See firmware_info.json in the package for detailed information.
+        draft: false
+        prerelease: false

--- a/.github/workflows/esp32-c6-build-advanced.yml
+++ b/.github/workflows/esp32-c6-build-advanced.yml
@@ -2,11 +2,11 @@ name: Advanced ESP32-C6 Build with ESP-IDF 5.5
 
 on:
   push:
-    branches: [ main, master, develop ]
+    branches: [ main, master, develop, dev ]
     tags:
       - 'v*'
   pull_request:
-    branches: [ main, master, develop ]
+    branches: [ main, master, develop, dev ]
   workflow_dispatch:
     inputs:
       release_build:

--- a/.github/workflows/esp32-c6-build.yml
+++ b/.github/workflows/esp32-c6-build.yml
@@ -2,9 +2,9 @@ name: Build ESP32-C6 with ESP-IDF 5.5
 
 on:
   push:
-    branches: [ main, master, develop ]
+    branches: [ main, master, develop, dev ]
   pull_request:
-    branches: [ main, master, develop ]
+    branches: [ main, master, develop, dev ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/esp32-c6-build.yml
+++ b/.github/workflows/esp32-c6-build.yml
@@ -1,0 +1,60 @@
+name: Build ESP32-C6 with ESP-IDF 5.5
+
+on:
+  push:
+    branches: [ main, master, develop ]
+  pull_request:
+    branches: [ main, master, develop ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: Setup ESP-IDF
+      uses: espressif/setup-esp-idf@v1
+      with:
+        esp-idf-version: v5.5
+        targets: esp32c6
+
+    - name: Build project
+      run: |
+        . ${IDF_PATH}/export.sh
+        idf.py build
+
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: esp32-c6-firmware
+        path: |
+          build/bootloader/bootloader.bin
+          build/partition_table/partition-table.bin
+          build/*.bin
+          build/*.elf
+          build/*.map
+        retention-days: 30
+
+    - name: Check binary size
+      run: |
+        . ${IDF_PATH}/export.sh
+        idf.py size
+        idf.py size-components
+
+    - name: Generate flash instructions
+      run: |
+        echo "Flash command:" > flash_instructions.txt
+        echo "esptool.py -p PORT -b 460800 --before default_reset --after hard_reset --chip esp32c6 write_flash --flash_mode dio --flash_size detect --flash_freq 80m 0x0 build/bootloader/bootloader.bin 0x8000 build/partition_table/partition-table.bin 0x10000 build/*.bin" >> flash_instructions.txt
+        cat flash_instructions.txt
+
+    - name: Upload flash instructions
+      uses: actions/upload-artifact@v4
+      with:
+        name: flash-instructions
+        path: flash_instructions.txt
+        retention-days: 30

--- a/.github/workflows/esp32-c6-simple-build.yml
+++ b/.github/workflows/esp32-c6-simple-build.yml
@@ -1,0 +1,32 @@
+name: Simple ESP32-C6 Build
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: ESP-IDF Build
+      uses: espressif/esp-idf-ci-action@v1
+      with:
+        esp_idf_version: v5.5
+        target: esp32c6
+        path: '.'
+
+    - name: Upload firmware
+      uses: actions/upload-artifact@v4
+      with:
+        name: firmware
+        path: |
+          build/*.bin
+          build/*.elf
+          build/bootloader/bootloader.bin
+          build/partition_table/partition-table.bin

--- a/main/display.c
+++ b/main/display.c
@@ -6,6 +6,7 @@
 static const char *TAG = "display";
 
 void display_task(void* pvParameters) {
+    ESP_LOGI(TAG, "Display task started");
     // TODO: setup i2c
 
     while (1) {

--- a/main/moisture_sensor.c
+++ b/main/moisture_sensor.c
@@ -15,7 +15,7 @@ static const char *TAG = "moisture_sensor";
 // For ESP32-C6, ADC1 channels are available on specific GPIOs
 #define ADC_UNIT        ADC_UNIT_1
 #define ADC_CHANNEL     ADC_CHANNEL_0   // GPIO0 for ESP32-C6
-#define ADC_ATTEN       ADC_ATTEN_DB_12
+#define ADC_ATTEN       ADC_ATTEN_DB_11  // Use DB_11 for ESP-IDF v5.1
 
 static adc_oneshot_unit_handle_t adc1_handle;
 static adc_cali_handle_t adc_cali_handle = NULL;
@@ -35,14 +35,14 @@ void setup_adc(void) {
     };
     ESP_ERROR_CHECK(adc_oneshot_config_channel(adc1_handle, ADC_CHANNEL, &config));
 
-    // Try to calibrate ADC
-    adc_cali_curve_fitting_config_t cali_config = {
+    // Try to calibrate ADC using line fitting for ESP32-C6
+    adc_cali_line_fitting_config_t cali_config = {
         .unit_id = ADC_UNIT,
         .atten = ADC_ATTEN,
         .bitwidth = ADC_BITWIDTH_DEFAULT,
     };
 
-    if (adc_cali_create_scheme_curve_fitting(&cali_config, &adc_cali_handle) == ESP_OK) {
+    if (adc_cali_create_scheme_line_fitting(&cali_config, &adc_cali_handle) == ESP_OK) {
         do_calibration = true;
         ESP_LOGI(TAG, "ADC calibration enabled");
     } else {

--- a/main/moisture_sensor.c
+++ b/main/moisture_sensor.c
@@ -15,7 +15,7 @@ static const char *TAG = "moisture_sensor";
 // For ESP32-C6, ADC1 channels are available on specific GPIOs
 #define ADC_UNIT        ADC_UNIT_1
 #define ADC_CHANNEL     ADC_CHANNEL_0   // GPIO0 for ESP32-C6
-#define ADC_ATTEN       ADC_ATTEN_DB_11  // Use DB_11 for ESP-IDF v5.1
+#define ADC_ATTEN       ADC_ATTEN_DB_12  // Available in ESP-IDF 5.5
 
 static adc_oneshot_unit_handle_t adc1_handle;
 static adc_cali_handle_t adc_cali_handle = NULL;
@@ -36,6 +36,7 @@ void setup_adc(void) {
     ESP_ERROR_CHECK(adc_oneshot_config_channel(adc1_handle, ADC_CHANNEL, &config));
 
     // Try to calibrate ADC using line fitting for ESP32-C6
+    // ESP32-C6 only supports line fitting calibration scheme
     adc_cali_line_fitting_config_t cali_config = {
         .unit_id = ADC_UNIT,
         .atten = ADC_ATTEN,


### PR DESCRIPTION
Fix ADC compilation errors in `moisture_sensor.c` and resolve unused variable warning in `display.c`.

The `moisture_sensor.c` compilation failed because ESP32-C6 only supports line fitting for ADC calibration, not curve fitting. This PR updates the ADC calibration configuration and function calls accordingly. The `display.c` warning was resolved by using the `TAG` variable in a log statement.

---
<a href="https://cursor.com/background-agent?bcId=bc-658c4ec2-6702-49d4-b328-e4d7497fa0ad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-658c4ec2-6702-49d4-b328-e4d7497fa0ad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

